### PR TITLE
Rename heading to trackAngle in GroundSpeed calculations for clarity

### DIFF
--- a/adsb/message.go
+++ b/adsb/message.go
@@ -278,8 +278,8 @@ func (m *Message) VerticalSpeed() (float64, error) {
 
 // Ground speed decoding with GNSS information, in m/s.
 // velocity: in m/s.
-// heading: in degrees with range (-180, 180], where the north is 0, east is 90, south is 180, west is -90.
-func (m *Message) GroundSpeed() (velocity, heading float64, err error) {
+// trackAngle: in degrees with range (-180, 180], where the north is 0, east is 90, south is 180, west is -90.
+func (m *Message) GroundSpeed() (velocity, trackAngle float64, err error) {
 	df, err := m.raw.DF()
 	if err != nil {
 		return 0.0, 0.0, newError(ErrNotAvailable, "err decode DF")
@@ -325,7 +325,7 @@ func (m *Message) GroundSpeed() (velocity, heading float64, err error) {
 	}
 
 	velocity = math.Sqrt(vEW*vEW+vNS*vNS) * KNOT_TO_MPS
-	heading = math.Atan2(vEW, vNS) * 180.0 / math.Pi
+	trackAngle = math.Atan2(vEW, vNS) * 180.0 / math.Pi
 
-	return velocity, heading, nil
+	return velocity, trackAngle, nil
 }

--- a/adsb/message_test.go
+++ b/adsb/message_test.go
@@ -956,21 +956,21 @@ func testGroundSpeed(t *testing.T) {
 		return
 	}
 
-	velocity, heading, err := m.GroundSpeed()
+	velocity, trackAngle, err := m.GroundSpeed()
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	log.Printf("velocity: %v m/s, heading: %v degrees", velocity, heading)
+	log.Printf("velocity: %v m/s, trackAngle: %v degrees", velocity, trackAngle)
 
 	if math.Abs(velocity-114.8145) > 0.001 {
 		t.Errorf("incorrect velocity")
 		return
 	}
 
-	if math.Abs(heading-101.1085) > 0.001 {
-		t.Error("incorrect heading")
+	if math.Abs(trackAngle-101.1085) > 0.001 {
+		t.Error("incorrect trackAngle")
 		return
 	}
 


### PR DESCRIPTION
This pull request updates the variable name `heading` to `trackAngle` in the `GroundSpeed()` function and related test cases to improve accuracy and clarity in the codebase.
	•	Why the change?
	•	The term “heading” refers to the aircraft’s nose direction, which is not what the calculation in GroundSpeed() provides.
	•	The calculated value is the track angle, which indicates the actual direction of motion over the ground.
	•	This aligns with aviation terminology and prevents confusion when reading the code.
	•	What was updated?
	•	Renamed heading to trackAngle in the GroundSpeed() function.
	•	Updated all relevant references in:
	•	message.go
	•	message_test.go
	•	Ensured print statements and log outputs reflect the updated terminology (trackAngle).
	•	Consistency ensured:
	•	All related printouts and variable references were updated to match the new naming convention.
	•	Tests were verified to confirm correctness.

This rename improves code clarity and better aligns with ADS-B data terminology. Let me know if further adjustments are needed!